### PR TITLE
doc: add godoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-general
-=======
+# root [![GoDoc](https://godoc.org/github.com/gonum/root?status.svg)](https://godoc.org/github.com/gonum/root)
+
 Package root provides algorithms to calculate the zero value of a function.
 This package is in development, so use at your own risk. API is still likely to change.


### PR DESCRIPTION
- add a godoc badge link
- fixed copy/paste mistake in package name